### PR TITLE
[BOJ] 1021 회전하는 큐 / 2164 카드2

### DIFF
--- a/BOJ/1021_큐/4923.py
+++ b/BOJ/1021_큐/4923.py
@@ -1,0 +1,22 @@
+# https://www.acmicpc.net/problem/1021
+
+from collections import deque
+
+N, _ = map(int, input().split())
+numbers = map(int, input().split())
+Q = deque([i + 1 for i in range(N)])
+
+cnt = 0
+for number in numbers:
+    idx = Q.index(number)
+    if Q[0] == number:
+        pass
+    elif idx < len(Q) / 2:
+        Q.rotate(-idx)
+    else:
+        idx = len(Q) - idx
+        Q.rotate(idx)
+    cnt += idx
+    Q.popleft()
+
+print(cnt)

--- a/BOJ/2164_카드2/4923.py
+++ b/BOJ/2164_카드2/4923.py
@@ -1,0 +1,22 @@
+from collections import deque
+
+
+def card2(N, Q):
+    for _ in range(N - 1):
+        Q.popleft()  # 맨 위의 카드는 제거
+        Q.append(Q.popleft())
+    return Q[0]
+
+
+def main():
+    # N = int(input("Input N : "))      # BOJ 오답처리
+    N = int(input())  # BOJ 정답
+    Q = deque([num + 1 for num in range(N)])
+    last_card = card2(N, Q)
+    print(last_card)
+
+    print(type(last_card))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 1021 회전하는 큐
원래 index로 풀어보려고 했는데 삭제 조건이 들어가 있어서 count나 None 의 개수를 세지 않고는 풀 수 없게 되었음.
불필요한 연산 횟수가 늘어나고 시간 복잡도가 커질 뿐 아니라 최악의 경우 `.count`는 O(N) 이므로 for문 안에서 count를 쓰면 O(N^2)이 되므로 시도해보다 해당 방법 폐기.
- [관련 issue](https://github.com/4923/GwangjuAI2/issues/1)
- 그리고 어차피 rotate도 idx로 돌려서... 결국 내가 원하던 방법과 같게 풀린 것 같다. 난 또 for문 두 번 돌려야 하는 줄 알았지...

순서에 약해서 회전큐 할 때도 어려웠는데 이 문제도 어지간히 고통받았다.
공통된 작업인 popleft와 결과값 cnt 조정은 맨 마지막으로 뺐다.

## 2164 카드2
같이 푼 문제라 올렸다.
예전에 백준에서 채점했을 땐 input 안내문구 넣어도 무시됐던거 같은데 이 문제는 그거 넣으면 바로 오답 뜬다.
아까운 내 제출 횟수...
- [관련 issue](https://github.com/4923/GwangjuAI2/issues/2)를 남긴다.